### PR TITLE
Add `config.toml` parser && move `apiHttpPort` and `txId` to the config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,7 @@
+title = "Application config file"
+
+[server]
+apiHttpPort = 9999
+
+[transaction]
+txId = "85ca051bf5225ade34b1724d78d5833d6d82b3d7d7d23f35f585d504e068ee5a"

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -28,11 +28,13 @@ import Path.IO qualified as Path
 import Yare.App qualified as Yare
 import Yare.App.Types qualified as App
 import Yare.Chain.Point (ChainPoint, parseChainPoint)
+import Yare.Config.Toml qualified as Toml
 import Yare.Node.Socket (NodeSocket (..))
 
 main ∷ IO ()
 main = withUtf8 do
   Args {networkMagic, nodeSocketPath, mnemonicPath, syncFrom} ← parseArguments
+  Toml.Config {apiHttpPort, txId} ← Toml.readConfig
   nodeSocket ←
     NodeSocket <$> case nodeSocketPath of
       Path.Abs a → pure a
@@ -43,11 +45,12 @@ main = withUtf8 do
       Path.Rel r → Path.makeAbsolute r
   Yare.start
     App.Config
-      { apiHttpPort = 9999
+      { apiHttpPort
       , nodeSocket
       , networkMagic
       , mnemonicFile
       , syncFrom
+      , txId
       }
 
 type Args ∷ Type

--- a/lib/Yare/App.hs
+++ b/lib/Yare/App.hs
@@ -86,25 +86,20 @@ Starts several threads concurrently:
   * Local transaction submission
 -}
 start ∷ App.Config → IO ()
-start config@App.Config {apiHttpPort} = do
+start config@App.Config {apiHttpPort, txId} = do
   queryQ ← liftIO newTQueueIO
   submitQ ← liftIO newTQueueIO
   storage ← Storage.inMemory <$> newIORef initialChainState
-  feesInput ← initializeFeesInput
+  feesInput ← initializeFeesInput txId
   concurrently_
     (runWebServer apiHttpPort storage queryQ submitQ feesInput)
     (runNodeConnection config storage queryQ submitQ)
 
-initializeFeesInput ∷ IO TxIn
-initializeFeesInput = withHandledErrors do
-  let
-    txId ∷ ByteString -- TODO: move to config
-    txId = "85ca051bf5225ade34b1724d78d5833d6d82b3d7d7d23f35f585d504e068ee5a"
-
+initializeFeesInput ∷ ByteString → IO TxIn
+initializeFeesInput txId = withHandledErrors do
   txIdHash ←
     Crypto.hashFromBytes txId
       & Oops.hoistMaybe (InvalidTxIdHash txId)
-
   pure (TxIn (TxId txIdHash) (TxIx 0))
 
 -- | Retrieves the UTXO set from a storage.
@@ -174,27 +169,27 @@ deployScript submitQ networkInfo feesInput = do
       bodyContent =
         Api.TxBodyContent
           { txIns = [feesInput]
-          , txInsCollateral = _
-          , txInsReference = _
-          , txOuts = _
-          , txTotalCollateral = _
-          , txReturnCollateral = _
-          , txFee = _
-          , txValidityLowerBound = _
-          , txValidityUpperBound = _
-          , txMetadata = _
-          , txAuxScripts = _
-          , txExtraKeyWits = _
-          , txProtocolParams = _
-          , txWithdrawals = _
-          , txCertificates = _
-          , txUpdateProposal = _
-          , txMintValue = _
-          , txScriptValidity = _
-          , txProposalProcedures = _
-          , txVotingProcedures = _
-          , txCurrentTreasuryValue = _
-          , txTreasuryDonation = _
+          , txInsCollateral = undefined
+          , txInsReference = undefined
+          , txOuts = undefined
+          , txTotalCollateral = undefined
+          , txReturnCollateral = undefined
+          , txFee = undefined
+          , txValidityLowerBound = undefined
+          , txValidityUpperBound = undefined
+          , txMetadata = undefined
+          , txAuxScripts = undefined
+          , txExtraKeyWits = undefined
+          , txProtocolParams = undefined
+          , txWithdrawals = undefined
+          , txCertificates = undefined
+          , txUpdateProposal = undefined
+          , txMintValue = undefined
+          , txScriptValidity = undefined
+          , txProposalProcedures = undefined
+          , txVotingProcedures = undefined
+          , txCurrentTreasuryValue = undefined
+          , txTreasuryDonation = undefined
           }
 
   let changeAddr ∷ Api.AddressInEra era

--- a/lib/Yare/App/Types.hs
+++ b/lib/Yare/App/Types.hs
@@ -32,6 +32,7 @@ data Config = Config
   , networkMagic ∷ NetworkMagic
   , mnemonicFile ∷ Tagged "mnemonic" (Path Abs File)
   , syncFrom ∷ Maybe ChainPoint -- TODO: let app decide it based on the persistent state
+  , txId ∷ ByteString
   }
 
 type NetworkInfo ∷ Type → Type

--- a/lib/Yare/Config/Toml.hs
+++ b/lib/Yare/Config/Toml.hs
@@ -1,0 +1,33 @@
+module Yare.Config.Toml (Config (..), readConfig, readConfigFrom) where
+
+import Relude
+
+import Control.Exception (throw)
+import Data.ByteString.Char8 (pack)
+import Network.Wai.Handler.Warp (Port)
+import TOML.Decode (DecodeTOML (..), Decoder, decodeFile, getFields)
+
+-- | Data that must be present in `toml.config`
+type Config ∷ Type
+data Config = Config
+  { apiHttpPort ∷ Port
+  , txId ∷ ByteString
+  }
+
+instance DecodeTOML Config where
+  tomlDecoder =
+    Config
+      <$> portField
+      <*> txIdField
+   where
+    txIdField ∷ Decoder ByteString
+    txIdField = getFields ["transaction", "txId"] <&> pack
+
+    portField ∷ Decoder Port
+    portField = getFields ["server", "apiHttpPort"]
+
+readConfigFrom ∷ FilePath → IO Config
+readConfigFrom pathToConfig = decodeFile pathToConfig >>= either throw pure
+
+readConfig ∷ IO Config
+readConfig = readConfigFrom "./config.toml"

--- a/lib/Yare/Config/Toml.hs
+++ b/lib/Yare/Config/Toml.hs
@@ -7,7 +7,7 @@ import Data.ByteString.Char8 (pack)
 import Network.Wai.Handler.Warp (Port)
 import TOML.Decode (DecodeTOML (..), Decoder, decodeFile, getFields)
 
--- | Data that must be present in `toml.config`
+-- | Data that must be present in `config.toml`
 type Config ∷ Type
 data Config = Config
   { apiHttpPort ∷ Port

--- a/yare.cabal
+++ b/yare.cabal
@@ -108,6 +108,7 @@ library
     , strict-sop-core                ^>=0.1.1
     , string-interpolate             ^>=0.3.3
     , text-ansi                      ^>=0.3.0.1
+    , toml-reader                    ^>=0.2.1.0
     , wai                            ^>=3.2.4
     , wai-cors                       ^>=0.2.7
     , wai-extra                      ^>=3.1.15
@@ -126,6 +127,7 @@ library
     Yare.Chain.Sync
     Yare.Chain.Tx
     Yare.Chain.Types
+    Yare.Config.Toml
     Yare.Http.Server
     Yare.Http.Types
     Yare.Mnemonic


### PR DESCRIPTION
Now, instead of hardcoding `apiHttpPort` and `txId`, we put them into `config.toml` and then parse before starting the application. 

TODO: check `txId` length on acquiring it.