### PR TITLE
API endpoint for addresses rebalancing

### DIFF
--- a/lib/Yare/App/Services.hs
+++ b/lib/Yare/App/Services.hs
@@ -49,6 +49,7 @@ data Services m = Services
   , serveTransactionsInLedger ∷ m (Set TxId)
   , serveTransactionsSubmitted ∷ m (Set TxId)
   , requestMinting ∷ AssetName → m (PolicyId, TxId)
+  , requestRebalancing ∷ m TxId
   }
 
 mkServices
@@ -97,6 +98,7 @@ mkServices env =
         lookTagged @"submitted" @(Set TxId) <$> readDefaultStorage @state env
     , requestMinting =
         Minting.service @era @state env
+    , requestRebalancing = $(todo "requestRebalancing")
     }
 
 scriptAddresses ∷ Network → [LedgerAddress]

--- a/lib/Yare/Http/Server.hs
+++ b/lib/Yare/Http/Server.hs
@@ -69,8 +69,7 @@ type YareApi =
                   :<|> "change" :> Get '[JSON] [Http.Address]
                   :<|> "fees" :> Get '[JSON] [Http.Address]
                   :<|> "collateral" :> Get '[JSON] [Http.Address]
-                  :<|> "rebalance"
-                    :> Post '[JSON] TxId
+                  :<|> "rebalance" :> Post '[JSON] TxId
                   :<|> "scripts" :> Get '[JSON] [Http.Address]
                )
           :<|> "transactions"
@@ -178,9 +177,7 @@ endpointAddressesCollateral ∷ App.Services IO → Servant.Handler [Http.Addres
 endpointAddressesCollateral App.Services {serveCollateralAddresses} = liftIO do
   Http.Address.fromLedgerAddress <<$>> serveCollateralAddresses
 
-endpointAddressesRebalance
-  ∷ App.Services IO
-  → Servant.Handler TxId
+endpointAddressesRebalance ∷ App.Services IO → Servant.Handler TxId
 endpointAddressesRebalance App.Services {requestRebalancing} = liftIO requestRebalancing
 
 endpointAddressesScripts ∷ App.Services IO → Servant.Handler [Http.Address]

--- a/lib/Yare/Http/Server.hs
+++ b/lib/Yare/Http/Server.hs
@@ -69,6 +69,8 @@ type YareApi =
                   :<|> "change" :> Get '[JSON] [Http.Address]
                   :<|> "fees" :> Get '[JSON] [Http.Address]
                   :<|> "collateral" :> Get '[JSON] [Http.Address]
+                  :<|> "rebalance"
+                    :> Post '[JSON] TxId
                   :<|> "scripts" :> Get '[JSON] [Http.Address]
                )
           :<|> "transactions"
@@ -99,6 +101,7 @@ application services =
               :<|> endpointAddressesChange services
               :<|> endpointAddressesFees services
               :<|> endpointAddressesCollateral services
+              :<|> endpointAddressesRebalance services
               :<|> endpointAddressesScripts services
            )
       :<|> ( endpointTransactions services
@@ -149,7 +152,7 @@ endpointScriptDeployments App.Services {serveScriptDeployments} = liftIO do
   pure $ uncurry Http.ScriptDeployment <$> Map.toList deployments
 
 endpointScriptDeployment
-  ∷ Services IO
+  ∷ App.Services IO
   → ScriptHash
   → Servant.Handler Http.ScriptDeployment
 endpointScriptDeployment services scriptHash = do
@@ -174,6 +177,11 @@ endpointAddressesFees App.Services {serveFeeAddresses} = liftIO do
 endpointAddressesCollateral ∷ App.Services IO → Servant.Handler [Http.Address]
 endpointAddressesCollateral App.Services {serveCollateralAddresses} = liftIO do
   Http.Address.fromLedgerAddress <<$>> serveCollateralAddresses
+
+endpointAddressesRebalance
+  ∷ App.Services IO
+  → Servant.Handler TxId
+endpointAddressesRebalance App.Services {requestRebalancing} = liftIO requestRebalancing
 
 endpointAddressesScripts ∷ App.Services IO → Servant.Handler [Http.Address]
 endpointAddressesScripts App.Services {serveScriptAddresses} = liftIO do


### PR DESCRIPTION
Closes #8 . 
Endpoint implementation for redistributing funds across wallet's addresses. See #8 for details.